### PR TITLE
EUMM, Transformers and command line options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,14 @@ perl:
   - "5.18"
   - "5.16"
   - "5.14"
-branches:
-  only:
-    - master
-    - develop
+install:
+  - cpanm --quiet --installdeps --notest .
+script:
+  - perl Makefile.PL
+  - make
+  - make dist
+  - tar zxvf *.tar.gz
+  - cd p5-App-DSC-DataTool-[0-9]*
+  - perl Makefile.PL
+  - make
+  - make test

--- a/MANIFEST
+++ b/MANIFEST
@@ -13,7 +13,8 @@ lib/App/DSC/DataTool/Output/Carbon.pm
 lib/App/DSC/DataTool/Output.pm
 lib/App/DSC/DataTool/Outputs.pm
 lib/App/DSC/DataTool.pm
-lib/App/DSC/DataTool/Transformer/GroupRange.pm
+lib/App/DSC/DataTool/Transformer/Labler.pm
+lib/App/DSC/DataTool/Transformer/ReRanger.pm
 lib/App/DSC/DataTool/Transformer.pm
 lib/App/DSC/DataTool/Transformers.pm
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,28 +37,58 @@ use ExtUtils::MakeMaker;
 
 WriteMakefile(
     NAME          => 'App::DSC::DataTool',
+    DISTNAME      => 'p5-App-DSC-DataTool',
     AUTHOR        => q{Jerry Lundström <lundstrom.jerry@gmail.com>},
     VERSION_FROM  => 'lib/App/DSC/DataTool.pm',
-    ABSTRACT_FROM => 'lib/App/DSC/DataTool.pm',
+    ABSTRACT      => 'Export DSC data to other formats and/or databases',
     EXE_FILES     => ['bin/dsc-datatool'],
     (
         !eval { ExtUtils::MakeMaker->VERSION( 6.3002 ) }
         ? ()
-        : ( LICENSE => 'perl' )
+        : ( LICENSE => 'bsd' )
     ),
     (
-        PREREQ_PM => {
-            'Test::More'          => 0,
-            'common::sense'       => 3,
-            'XML::LibXML::Simple' => 0.93,
-            'IO::Socket::INET'    => 1.31,
-            'Time::HiRes'         => 0,
-            'Getopt::Long'        => 0,
-            'YAML::Tiny'          => 0,
-            'Pod::Usage'          => 0,
-            'Scalar::Util'        => 0,
-            'Module::Find'        => 0,
-        }
+        eval { ExtUtils::MakeMaker->VERSION( 6.5503 ) }
+        ? (
+            BUILD_REQUIRES => {
+                'Test::More'          => 0,
+                'Test::CheckManifest' => 0.9,
+                'common::sense'       => 3,
+                'XML::LibXML::Simple' => 0.93,
+                'IO::Socket::INET'    => 1.31,
+                'Time::HiRes'         => 0,
+                'Getopt::Long'        => 0,
+                'YAML::Tiny'          => 0,
+                'Pod::Usage'          => 0,
+                'Scalar::Util'        => 0,
+                'Module::Find'        => 0,
+            },
+            PREREQ_PM => {
+                'common::sense'       => 3,
+                'XML::LibXML::Simple' => 0.93,
+                'IO::Socket::INET'    => 1.31,
+                'Time::HiRes'         => 0,
+                'Getopt::Long'        => 0,
+                'YAML::Tiny'          => 0,
+                'Pod::Usage'          => 0,
+                'Scalar::Util'        => 0,
+                'Module::Find'        => 0,
+            }
+          )
+        : (
+            PREREQ_PM => {
+                'Test::More'          => 0,
+                'common::sense'       => 3,
+                'XML::LibXML::Simple' => 0.93,
+                'IO::Socket::INET'    => 1.31,
+                'Time::HiRes'         => 0,
+                'Getopt::Long'        => 0,
+                'YAML::Tiny'          => 0,
+                'Pod::Usage'          => 0,
+                'Scalar::Util'        => 0,
+                'Module::Find'        => 0,
+            }
+        )
     ),
     (
         !eval { ExtUtils::MakeMaker->VERSION( 6.46 ) }
@@ -74,5 +104,5 @@ WriteMakefile(
         )
     ),
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
-    clean => { FILES    => 'App-DSC-DataTool-*' },
+    clean => { FILES    => 'p5-App-DSC-DataTool-*' },
 );

--- a/bin/dsc-datatool
+++ b/bin/dsc-datatool
@@ -24,23 +24,29 @@ my $list;
 my $man;
 my $help;
 my $verbose = 0;
+my $version;
 
 GetOptions(
-    'conf=s'      => \$conf,
-    'server=s'    => \$server,
-    'node=s'      => \$node,
-    'xml=s'       => \@xml,
-    'dat=s'       => \@dat,
-    'dataset=s'   => \@dataset,
-    'output=s'    => \@output,
-    'transform=s' => \@transform,
-    'list:s'      => \$list,
-    'help|?'      => \$help,
-    'man'         => \$man,
-    'verbose+'    => \$verbose,
+    'conf=s'       => \$conf,
+    'server=s'     => \$server,
+    'node=s'       => \$node,
+    'xml=s'        => \@xml,
+    'dataset|ds=s' => \@dataset,
+    'dat|d=s'      => \@dat,
+    'output=s'     => \@output,
+    'transform=s'  => \@transform,
+    'list:s'       => \$list,
+    'help|?'       => \$help,
+    'man'          => \$man,
+    'version|V'    => \$version,
+    'verbose|v+'   => \$verbose,
 ) or pod2usage( 2 );
 pod2usage( 1 ) if $help;
 pod2usage( -exitval => 0, -verbose => 2 ) if $man;
+if ( $version ) {
+    say 'dsc-datatool version ', App::DSC::DataTool->VERSION;
+    exit 0;
+}
 unless ( $server and $node and ( scalar @xml or scalar @dat ) ) {
     pod2usage(
         -msg     => '--server, --node and either a --xml or --dat must be given',
@@ -179,27 +185,27 @@ B<--list> to see the list of available output plugins.
 
 =over 8
 
-=item B<--conf <file>>
+=item B<[ -c | --conf ] <file>>
 
 Specify the YAML configuration file to use (default to ~/.dsc-datatool.conf),
 any command line option will override the options in the configuration file.
 See B<dsc-datatool.conf(5)> for more information.
 
-=item B<--server <name>> (required)
+=item B<[ -s | --server ] <name>> (required)
 
 Specify the server for where the data comes from.
 
-=item B<--node <name>> (required)
+=item B<[ -n | --node ] <name>> (required)
 
 Specify the node for where the data comes from.
 
-=item B<--xml <file or directory>> (suggested)
+=item B<[ -x | --xml ] <file or directory>> (suggested)
 
 Read DSC data from the given file or directory, can be specified multiple
 times.
 If a directory is given then all files ending with B<.xml> will be read.
 
-=item B<--dat <file or directory>> (suggested)
+=item B<[ -d | --dat ] <file or directory>> (suggested)
 
 Read DSC data from the given file or directory, can be specified multiple
 times.
@@ -208,12 +214,12 @@ read.
 Note that the DAT format is depended on the filename to know what type
 of data it is.
 
-=item B<--dataset <list of datasets>>
+=item B<[ -ds | --dataset ] <list of datasets>>
 
 Specify that only the list of datasets will be processed, the list is comma
 separated and the option can be given multiple times.
 
-=item B<--output <sep><type>[<sep>option=value...]>
+=item B<[ -o | --output ] <sep><type>[<sep>option=value...]>
 
 Output data to B<type> and use B<separator> as an options separator, example:
 
@@ -225,12 +231,12 @@ To see a full list of options, check the man-page of the output module:
 
   man App:DSC::DataTool::Output::NAME
 
-=item B<--transform <sep><type><sep><datasets>[<sep>option=value...]>
+=item B<[ -t | --transform ] <sep><type><sep><datasets>[<sep>option=value...]>
 
 Use the transformer B<type> to change the list of datasets in B<datasets>,
 example:
 
-  --transform ;GroupRange;rcode_vs_replylen;type=sum;range=/128
+  --transform ;ReRanger;rcode_vs_replylen;type=sum;range=/128
 
 B<datasets> is a comma separated list of datasets to run the tranformer on,
 because of this do not use comma (,) as a separator.  B<*> in B<datasets> will
@@ -248,21 +254,25 @@ To see a full list of options, check the man-page of the transformer module:
 For a list of datasets see the DSC configuration that created the data files
 and the documentation for the Presenter.
 
-=item B<--list [tr|transform|in|input|out|output|all]>
+=item B<[ -l | --list ] [tr|transform|in|input|out|output|all]>
 
 List the available transformers, input and output formats.
 
-=item B<--help>
+=item B<-h | --help>
 
 Print a brief help message and exits.
 
-=item B<--man>
+=item B<-m | --man>
 
 Prints the manual page and exits.
 
-=item B<--verbose>
+=item B<-v | --verbose>
 
 Increase the verbose level, can be given multiple times.
+
+=item B<-V | --version>
+
+Display version and exit.
 
 =back
 

--- a/lib/App/DSC/DataTool.pm
+++ b/lib/App/DSC/DataTool.pm
@@ -10,11 +10,11 @@ App::DSC::DataTool - Export DSC data to other formats and/or databases
 
 =head1 VERSION
 
-Version 1.00
+Version 0.01
 
 =cut
 
-our $VERSION = '1.00';
+our $VERSION = '0.01';
 
 =head1 SYNOPSIS
 

--- a/lib/App/DSC/DataTool/Transformer/Labler.pm
+++ b/lib/App/DSC/DataTool/Transformer/Labler.pm
@@ -1,15 +1,15 @@
-package App::DSC::DataTool::Input::DAT;
+package App::DSC::DataTool::Transformer::Labler;
 
 use common::sense;
 use Carp;
 
-use base qw( App::DSC::DataTool::Input );
+use base qw( App::DSC::DataTool::Transformer );
 
 =encoding utf8
 
 =head1 NAME
 
-App::DSC::DataTool::Input::DAT - DSC DAT input
+App::DSC::DataTool::Transformer::Labler - Set/change labels on dimensions
 
 =head1 VERSION
 
@@ -21,7 +21,7 @@ See L<App::DSC::DataTool> for version.
 
 =head1 DESCRIPTION
 
-DSC DAT input...
+Set/change labels on dimensions...
 
 =head1 METHODS
 
@@ -29,41 +29,19 @@ DSC DAT input...
 
 =item Init
 
-Initialize the DAT input, called from the input factory.
-
-=over 4
-
-=item server
-
-The server where the input comes from.
-
-=item node
-
-The node where the input comes from.
-
-=item file
-
-File to read input from.
-
-=back
+Initialize the transformer, called from the input factory.
 
 =cut
 
 sub Init {
     my ( $self, %args ) = @_;
 
-    foreach ( qw( server node file ) ) {
-        unless ( $args{$_} ) {
+    foreach ( qw( file ) ) {
+        unless ( defined $args{$_} ) {
             croak $_ . ' must be given';
         }
         $self->{$_} = $args{$_};
     }
-    unless ( -r $self->{file} ) {
-        croak 'file can not be read';
-    }
-
-    $self->{root}     = undef;
-    $self->{datasets} = [];
 
     return $self;
 }
@@ -80,7 +58,7 @@ sub Destroy {
 =cut
 
 sub Name {
-    return 'DAT';
+    return 'Labler';
 }
 
 =item Dataset
@@ -137,4 +115,4 @@ POSSIBILITY OF SUCH DAMAGE.
 
 =cut
 
-1;    # End of App::DSC::DataTool::Input::DAT
+1;    # End of App::DSC::DataTool::Transformer::Labler

--- a/lib/App/DSC/DataTool/Transformer/ReRanger.pm
+++ b/lib/App/DSC/DataTool/Transformer/ReRanger.pm
@@ -1,4 +1,4 @@
-package App::DSC::DataTool::Transformer::GroupRange;
+package App::DSC::DataTool::Transformer::ReRanger;
 
 use common::sense;
 use Carp;
@@ -9,7 +9,7 @@ use base qw( App::DSC::DataTool::Transformer );
 
 =head1 NAME
 
-App::DSC::DataTool::Transformer::GroupRange - Group data according to ranges
+App::DSC::DataTool::Transformer::ReRanger - (Re)Group data according to ranges
 
 =head1 VERSION
 
@@ -21,7 +21,7 @@ See L<App::DSC::DataTool> for version.
 
 =head1 DESCRIPTION
 
-Group data according to ranges...
+(Re)Group data according to ranges...
 
 =head1 METHODS
 
@@ -58,7 +58,7 @@ sub Destroy {
 =cut
 
 sub Name {
-    return 'GroupRange';
+    return 'ReRanger';
 }
 
 =item Dataset
@@ -66,9 +66,7 @@ sub Name {
 =cut
 
 sub Dataset {
-    my ( $self, $dataset ) = @_;
-
-    return $dataset;
+    croak 'Not implemented yet!';
 }
 
 =back
@@ -117,4 +115,4 @@ POSSIBILITY OF SUCH DAMAGE.
 
 =cut
 
-1;    # End of App::DSC::DataTool::Transformer::GroupRange
+1;    # End of App::DSC::DataTool::Transformer::ReRanger


### PR DESCRIPTION
Use better EUMM options and prefix dist with `p5`.
Rename GroupRange transformer and add Labler, make them croak if used.
Better documentation on command lines, add --version and see that all have short options.
Set version to 0.01.
Test dist on Travis.