### PR TITLE
restructure

### DIFF
--- a/dsc_datatool/__init__.py
+++ b/dsc_datatool/__init__.py
@@ -18,41 +18,12 @@ import sys
 import traceback
 import re
 
-
-parser = argparse.ArgumentParser(prog='dsc-datatool',
-    description='Export DSC data into various formats and databases.',
-    epilog='See man-page dsc-datatool(1) and dsc-datatool [generator|transformer|output] <name>(5) for more information')
-parser.add_argument('-c', '--conf', nargs=1,
-    help='Not implemented')
-#    help='Specify the YAML configuration file to use (default to ~/.dsc-datatool.conf), any command line option will override the options in the configuration file. See dsc-datatool.conf(5)for more information.')
-parser.add_argument('-s', '--server', nargs=1,
-    help='Specify the server for where the data comes from. (required)')
-parser.add_argument('-n', '--node', nargs=1,
-    help='Specify the node for where the data comes from. (required)')
-parser.add_argument('-x', '--xml', action='append',
-    help='Read DSC data from the given file or directory, can be specified multiple times. If a directory is given then all files ending with .xml will be read.')
-parser.add_argument('-d', '--dat', action='append',
-    help='Read DSC data from the given directory, can be specified multiple times. Note that the DAT format is depended on the filename to know what type of data it is.')
-parser.add_argument('--dataset', action='append',
-    help='Specify that only the list of datasets will be processed, the list is comma separated and the option can be given multiple times.')
-parser.add_argument('-o', '--output', action='append',
-    help='"<sep><output>[<sep>option=value...]>" Output data to <output> and use <separator> as an options separator.')
-parser.add_argument('-t', '--transform', action='append',
-    help='"<sep><name><sep><datasets>[<sep>option=value...]>" Use the transformer <name> to change the list of datasets in <datasets>.')
-parser.add_argument('-g', '--generator', action='append',
-    help='"<name>[,<name>,...]" or "<sep><name>[<sep>option=value...]>" Use the specified generators to generate additional datasets.')
-parser.add_argument('--list', action='store_true',
-    help='List the available generators, transformers and outputs then exit.')
-parser.add_argument('--skipped-key', nargs=1, default='-:SKIPPED:-',
-    help='Set the special DSC skipped key. (default to "-:SKIPPED:-")')
-parser.add_argument('--skipped-sum-key', nargs=1, default='-:SKIPPED_SUM:-',
-    help='Set the special DSC skipped sum key. (default to "-:SKIPPED_SUM:-")')
-parser.add_argument('-v', '--verbose', action='count', default=0,
-    help='Increase the verbose level, can be given multiple times.')
-parser.add_argument('-V', '--version', action='version', version='%(prog)s v'+__version__,
-    help='Display version and exit.')
-
-args = parser.parse_args()
+args = argparse.Namespace()
+inputs = {}
+outputs = {}
+generators = {}
+transformers = {}
+process_dataset = {}
 
 
 class Dataset(object):
@@ -83,17 +54,17 @@ class Dimension(object):
         return '<Dimension name=%r value=%r dimension=%r>' % (self.name, self.values or self.value, self.dimensions)
 
 
-_inputs = {}
 class Input(object):
     def process(self, file):
         raise Exception('process() not overloaded')
 
     def __init_subclass__(cls):
-        global _inputs
-        _inputs[cls.__name__] = cls
+        global inputs
+        if cls.__name__ in inputs:
+            raise Exception('Duplicate input module: %s already exists' % cls.__name__)
+        inputs[cls.__name__] = cls
 
 
-_outputs = {}
 class Output(object):
     def process(self, datasets):
         raise Exception('process() not overloaded')
@@ -102,11 +73,12 @@ class Output(object):
         pass
 
     def __init_subclass__(cls):
-        global _outputs
-        _outputs[cls.__name__] = cls
+        global outputs
+        if cls.__name__ in outputs:
+            raise Exception('Duplicate output module: %s already exists' % cls.__name__)
+        outputs[cls.__name__] = cls
 
 
-_generators = {}
 class Generator(object):
     def process(self, datasets):
         raise Exception('process() not overloaded')
@@ -115,11 +87,12 @@ class Generator(object):
         pass
 
     def __init_subclass__(cls):
-        global _generators
-        _generators[cls.__name__] = cls
+        global generators
+        if cls.__name__ in generators:
+            raise Exception('Duplicate generator module: %s already exists' % cls.__name__)
+        generators[cls.__name__] = cls
 
 
-_transformers = {}
 class Transformer(object):
     def process(self, datasets):
         raise Exception('process() not overloaded')
@@ -128,105 +101,160 @@ class Transformer(object):
         pass
 
     def __init_subclass__(cls):
-        global _transformers
-        _transformers[cls.__name__] = cls
+        global transformers
+        if cls.__name__ in transformers:
+            raise Exception('Duplicate transformer module: %s already exists' % cls.__name__)
+        transformers[cls.__name__] = cls
 
 
-def split_arg(arg, num=1):
-    sep = arg[0]
-    p = arg.split(sep)
-    p.pop(0)
-    ret = ()
-    while num > 0:
-        ret += (p.pop(0),)
-        num -= 1
-    ret += (p,)
-    return ret
+def main():
+    def iter_namespace(ns_pkg):
+        return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
 
 
-def parse_opts(opts):
-    ret = {}
-    for opt in opts:
-        p = opt.split('=', maxsplit=1)
-        if len(p) > 1:
-            if p[0] in ret:
-                if isinstance(ret[p[0]], list):
-                    ret[p[0]].append(p[1])
+    def split_arg(arg, num=1):
+        sep = arg[0]
+        p = arg.split(sep)
+        p.pop(0)
+        ret = ()
+        while num > 0:
+            ret += (p.pop(0),)
+            num -= 1
+        ret += (p,)
+        return ret
+
+
+    def parse_opts(opts):
+        ret = {}
+        for opt in opts:
+            p = opt.split('=', maxsplit=1)
+            if len(p) > 1:
+                if p[0] in ret:
+                    if isinstance(ret[p[0]], list):
+                        ret[p[0]].append(p[1])
+                    else:
+                        ret[p[0]] = [ ret[p[0]], p[1] ]
                 else:
-                    ret[p[0]] = [ ret[p[0]], p[1] ]
-            else:
-                ret[p[0]] = p[1]
-        elif len(p) > 0:
-            ret[p[0]] = True
-    return ret
+                    ret[p[0]] = p[1]
+            elif len(p) > 0:
+                ret[p[0]] = True
+        return ret
 
 
-def _process(datasets, generators, transformers, outputs):
-    gen_datasets = []
-    for generator in generators:
-        try:
-            gen_datasets += generator.process(datasets)
-        except Exception as e:
-            logging.warning('Generator %s failed: %s' % (generator, e))
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            for tb in traceback.format_tb(exc_traceback):
-                logging.warning(str(tb))
-            return 2
-
-    datasets += gen_datasets
-
-    if '*' in transformers:
-        for transformer in transformers['*']:
+    def _process(datasets, generators, transformers, outputs):
+        gen_datasets = []
+        for generator in generators:
             try:
-                transformer.process(datasets)
+                gen_datasets += generator.process(datasets)
             except Exception as e:
-                logging.warning('Transformer %s failed: %s' % (transformer, e))
+                logging.warning('Generator %s failed: %s' % (generator, e))
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 for tb in traceback.format_tb(exc_traceback):
                     logging.warning(str(tb))
                 return 2
-    for dataset in datasets:
-        if dataset.name in transformers:
-            for transformer in transformers[dataset.name]:
+
+        datasets += gen_datasets
+
+        if '*' in transformers:
+            for transformer in transformers['*']:
                 try:
-                    transformer.process([dataset])
+                    transformer.process(datasets)
                 except Exception as e:
                     logging.warning('Transformer %s failed: %s' % (transformer, e))
                     exc_type, exc_value, exc_traceback = sys.exc_info()
                     for tb in traceback.format_tb(exc_traceback):
                         logging.warning(str(tb))
                     return 2
+        for dataset in datasets:
+            if dataset.name in transformers:
+                for transformer in transformers[dataset.name]:
+                    try:
+                        transformer.process([dataset])
+                    except Exception as e:
+                        logging.warning('Transformer %s failed: %s' % (transformer, e))
+                        exc_type, exc_value, exc_traceback = sys.exc_info()
+                        for tb in traceback.format_tb(exc_traceback):
+                            logging.warning(str(tb))
+                        return 2
 
-    for output in outputs:
-        try:
-            output.process(datasets)
-        except Exception as e:
-            logging.warning('Output %s failed: %s' % (output, e))
-            exc_type, exc_value, exc_traceback = sys.exc_info()
-            for tb in traceback.format_tb(exc_traceback):
-                logging.warning(str(tb))
-            return 2
+        for output in outputs:
+            try:
+                output.process(datasets)
+            except Exception as e:
+                logging.warning('Output %s failed: %s' % (output, e))
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                for tb in traceback.format_tb(exc_traceback):
+                    logging.warning(str(tb))
+                return 2
 
-    return 0
+        return 0
 
 
-def main():
-    global args, _inputs, _outputs, _generators, _transformers
+    global args, inputs, outputs, generators, transformers, process_dataset
+
+    parser = argparse.ArgumentParser(prog='dsc-datatool',
+        description='Export DSC data into various formats and databases.',
+        epilog='See man-page dsc-datatool(1) and dsc-datatool-[generator|transformer|output] <name>(5) for more information')
+    parser.add_argument('-c', '--conf', nargs=1,
+        help='Not implemented')
+    #    help='Specify the YAML configuration file to use (default to ~/.dsc-datatool.conf), any command line option will override the options in the configuration file. See dsc-datatool.conf(5)for more information.')
+    parser.add_argument('-s', '--server', nargs=1,
+        help='Specify the server for where the data comes from. (required)')
+    parser.add_argument('-n', '--node', nargs=1,
+        help='Specify the node for where the data comes from. (required)')
+    parser.add_argument('-x', '--xml', action='append',
+        help='Read DSC data from the given file or directory, can be specified multiple times. If a directory is given then all files ending with .xml will be read.')
+    parser.add_argument('-d', '--dat', action='append',
+        help='Read DSC data from the given directory, can be specified multiple times. Note that the DAT format is depended on the filename to know what type of data it is.')
+    parser.add_argument('--dataset', action='append',
+        help='Specify that only the list of datasets will be processed, the list is comma separated and the option can be given multiple times.')
+    parser.add_argument('-o', '--output', action='append',
+        help='"<sep><output>[<sep>option=value...]>" Output data to <output> and use <separator> as an options separator.')
+    parser.add_argument('-t', '--transform', action='append',
+        help='"<sep><name><sep><datasets>[<sep>option=value...]>" Use the transformer <name> to change the list of datasets in <datasets>.')
+    parser.add_argument('-g', '--generator', action='append',
+        help='"<name>[,<name>,...]" or "<sep><name>[<sep>option=value...]>" Use the specified generators to generate additional datasets.')
+    parser.add_argument('--list', action='store_true',
+        help='List the available generators, transformers and outputs then exit.')
+    parser.add_argument('--skipped-key', nargs=1, default='-:SKIPPED:-',
+        help='Set the special DSC skipped key. (default to "-:SKIPPED:-")')
+    parser.add_argument('--skipped-sum-key', nargs=1, default='-:SKIPPED_SUM:-',
+        help='Set the special DSC skipped sum key. (default to "-:SKIPPED_SUM:-")')
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+        help='Increase the verbose level, can be given multiple times.')
+    parser.add_argument('-V', '--version', action='version', version='%(prog)s v'+__version__,
+        help='Display version and exit.')
+
+    args = parser.parse_args()
 
     log_level = 30 - (args.verbose * 10)
     if log_level < 0:
         log_level = 0
     logging.basicConfig(format='%(asctime)s %(levelname)s %(module)s: %(message)s', level=log_level, stream=sys.stderr)
 
+    import dsc_datatool.input
+    import dsc_datatool.output
+    import dsc_datatool.generator
+    import dsc_datatool.transformer
+
+    for finder, name, ispkg in iter_namespace(dsc_datatool.input):
+        importlib.import_module(name)
+    for finder, name, ispkg in iter_namespace(dsc_datatool.output):
+        importlib.import_module(name)
+    for finder, name, ispkg in iter_namespace(dsc_datatool.generator):
+        importlib.import_module(name)
+    for finder, name, ispkg in iter_namespace(dsc_datatool.transformer):
+        importlib.import_module(name)
+
     if args.list:
         print('Generators:')
-        for name in _generators:
+        for name in generators:
             print('',name)
         print('Transformers:')
-        for name in _transformers:
+        for name in transformers:
             print('',name)
         print('Outputs:')
-        for name in _outputs:
+        for name in outputs:
             print('',name)
         return 0
 
@@ -242,48 +270,47 @@ def main():
     elif not isinstance(args.node, str):
         raise Exception('Invalid argument for --node: %r' % args.node)
 
-    generators = []
+    gens = []
     if args.generator:
         for arg in args.generator:
             if not re.match(r'^\w', arg):
                 name, opts = split_arg(arg)
-                if not name in _generators:
+                if not name in generators:
                     logging.critical('Generator %s does not exist' % name)
                     return 1
-                generators.append(_generators[name](parse_opts(opts)))
+                gens.append(generators[name](parse_opts(opts)))
                 continue
             for name in arg.split(','):
-                if not name in _generators:
+                if not name in generators:
                     logging.critical('Generator %s does not exist' % name)
                     return 1
-                generators.append(_generators[name]({}))
+                gens.append(generators[name]({}))
 
-    transformers = {}
+    trans = {}
     if args.transform:
         for arg in args.transform:
             name, datasets, opts = split_arg(arg, num=2)
-            if not name in _transformers:
+            if not name in transformers:
                 logging.critical('Transformer %s does not exist' % name)
                 return 1
             for dataset in datasets.split(','):
-                if not dataset in transformers:
-                    transformers[dataset] = []
-                transformers[dataset].append(_transformers[name](parse_opts(opts)))
+                if not dataset in trans:
+                    trans[dataset] = []
+                trans[dataset].append(transformers[name](parse_opts(opts)))
 
-    outputs = []
+    out = []
     if args.output:
         for arg in args.output:
             name, opts = split_arg(arg)
-            if not name in _outputs:
+            if not name in outputs:
                 logging.critical('Output %s does not exist' % name)
                 return 1
-            outputs.append(_outputs[name](parse_opts(opts)))
+            out.append(outputs[name](parse_opts(opts)))
 
-    args.process_dataset = {}
     if args.dataset:
         for dataset in args.dataset:
             for p in dataset.split(','):
-                args.process_dataset[p] = True
+                process_dataset[p] = True
 
     xml = []
     if args.xml:
@@ -310,36 +337,18 @@ def main():
         logging.error('No valid --xml or --dat given')
         return 1
 
-    xml_input = _inputs['XML']()
+    xml_input = inputs['XML']()
     for file in xml:
         datasets = xml_input.process(file)
 
-        ret = _process(datasets, generators, transformers, outputs)
+        ret = _process(datasets, gens, trans, out)
         if ret > 0:
             return ret
 
-    dat_input = _inputs['DAT']()
+    dat_input = inputs['DAT']()
     for dir in dat:
         datasets = dat_input.process(dir)
 
-        ret = _process(datasets, generators, transformers, outputs)
+        ret = _process(datasets, gens, trans, out)
         if ret > 0:
             return ret
-
-
-def iter_namespace(ns_pkg):
-    return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
-
-import dsc_datatool.input
-import dsc_datatool.output
-import dsc_datatool.generator
-import dsc_datatool.transformer
-
-for finder, name, ispkg in iter_namespace(dsc_datatool.input):
-    importlib.import_module(name)
-for finder, name, ispkg in iter_namespace(dsc_datatool.output):
-    importlib.import_module(name)
-for finder, name, ispkg in iter_namespace(dsc_datatool.generator):
-    importlib.import_module(name)
-for finder, name, ispkg in iter_namespace(dsc_datatool.transformer):
-    importlib.import_module(name)

--- a/dsc_datatool/generator/client_ports_count.py
+++ b/dsc_datatool/generator/client_ports_count.py
@@ -10,6 +10,6 @@
 from dsc_datatool import Generator
 
 
-class client_subnet_authority(Generator):
-    def process(self, datasets):
-        raise Exception('not implemented')
+# class client_ports_count(Generator):
+#     def process(self, datasets):
+#         raise Exception('not implemented')

--- a/dsc_datatool/input/dat.py
+++ b/dsc_datatool/input/dat.py
@@ -9,7 +9,7 @@
 
 import re
 
-from dsc_datatool import Input, Dataset, Dimension, args
+from dsc_datatool import Input, Dataset, Dimension, process_dataset
 
 
 _dataset1d = [
@@ -52,21 +52,21 @@ class DAT(Input):
         datasets = []
 
         for d in _dataset1d:
-            if args.process_dataset and not d in args.process_dataset:
+            if process_dataset and not d in process_dataset:
                 continue
             try:
                 datasets += self.process1d('%s/%s.dat' % (dir, d), d)
             except FileNotFoundError:
                 pass
         for k, v in _dataset2d.items():
-            if args.process_dataset and not k in args.process_dataset:
+            if process_dataset and not k in process_dataset:
                 continue
             try:
                 datasets += self.process2d('%s/%s.dat' % (dir, k), k, v)
             except FileNotFoundError:
                 pass
         for k, v in _dataset3d.items():
-            if args.process_dataset and not k in args.process_dataset:
+            if process_dataset and not k in process_dataset:
                 continue
             try:
                 datasets += self.process3d('%s/%s.dat' % (dir, k), k, v[0], v[1])

--- a/dsc_datatool/input/xml.py
+++ b/dsc_datatool/input/xml.py
@@ -10,7 +10,7 @@
 import logging
 from xml.dom import minidom
 
-from dsc_datatool import Input, Dataset, Dimension, args
+from dsc_datatool import Input, Dataset, Dimension, process_dataset
 
 
 class XML(Input):
@@ -18,7 +18,7 @@ class XML(Input):
         dom = minidom.parse(file)
         datasets = []
         for array in dom.getElementsByTagName('array'):
-            if args.process_dataset and not array.getAttribute('name') in args.process_dataset:
+            if process_dataset and not array.getAttribute('name') in process_dataset:
                 continue
 
             dataset = Dataset()

--- a/dsc_datatool/transformer/labler.py
+++ b/dsc_datatool/transformer/labler.py
@@ -38,12 +38,14 @@ def _process(label, d):
 class Labler(Transformer):
     label = None
 
+
     def __init__(self, opts):
         if not 'yaml' in opts:
             raise Exception('yaml=file option required')
         f = open(opts.get('yaml'), 'r')
         self.label = yaml.load(f)
         f.close()
+
 
     def process(self, datasets):
         if self.label is None:

--- a/dsc_datatool/transformer/net_remap.py
+++ b/dsc_datatool/transformer/net_remap.py
@@ -16,6 +16,7 @@ class NetRemap(Transformer):
     v4net = None
     v6net = None
 
+
     def __init__(self, opts):
         net = opts.get('net', None)
         self.v4net = opts.get('v4net', net)


### PR DESCRIPTION
- Make `dsc_datatool` importable without it running anything
- Check for duplicated input, output, generator and transformer modules
- Move `process_dataset` from `args` to it's own global
- `generator/client_ports_count`:
  - Fix class name
  - Disable class until implemented