### PR TITLE
Input, YAML

### DIFF
--- a/dsc_datatool/__init__.py
+++ b/dsc_datatool/__init__.py
@@ -458,7 +458,11 @@ def main():
 
     xml_input = inputs['XML']()
     for file in xml:
-        datasets = xml_input.process(file)
+        try:
+            datasets = xml_input.process(file)
+        except Exception as e:
+            logging.critical('Unable to process XML file %s: %s' % (file, e))
+            return 1
 
         ret = _process(datasets, gens, trans, out)
         if ret > 0:
@@ -466,7 +470,11 @@ def main():
 
     dat_input = inputs['DAT']()
     for dir in dat:
-        datasets = dat_input.process(dir)
+        try:
+            datasets = dat_input.process(dir)
+        except Exception as e:
+            logging.critical('Unable to process DAT files in %s: %s' % (dir, e))
+            return 1
 
         ret = _process(datasets, gens, trans, out)
         if ret > 0:

--- a/dsc_datatool/transformer/labler.py
+++ b/dsc_datatool/transformer/labler.py
@@ -43,7 +43,10 @@ class Labler(Transformer):
         if not 'yaml' in opts:
             raise Exception('yaml=file option required')
         f = open(opts.get('yaml'), 'r')
-        self.label = yaml.load(f)
+        try:
+            self.label = yaml.full_load(f)
+        except AttributeError:
+            self.label = yaml.load(f)
         f.close()
 
 


### PR DESCRIPTION
- Fix #59: Handle input errors instead of dumping a stack trace
- `transformer/labler`: Use `yaml.full_load()` (as advised at https://msg.pyyaml.org/load) and fallback to `yaml.load()`