### PR TITLE
COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -19,5 +19,5 @@ srpm: prereq update-dist-tools
 	echo "$(spec)" | grep -q "develop.spec" && auto_build_number=`date --utc +%s` message="Auto build `date --utc --iso-8601=seconds`" "$(top)/dist-tools/spec-new-changelog-entry" || true
 	overwrite=yes nosign=yes "$(top)/dist-tools/create-source-packages" rpm
 	cp ../*.orig.tar.gz "$(top)/rpmbuild/SOURCES/"
-	echo "$(spec)" | grep -q "develop.spec" && rpmbuild -bs --define "%_topdir $(top)/rpmbuild" --undefine=dist rpm/dsc-datatool.spec || rpmbuild -bs --define "%_topdir $(top)/rpmbuild" --undefine=dist "$(spec)"
+	echo "$(spec)" | grep -q "develop.spec" && rpmbuild -bs --define "%_topdir $(top)/rpmbuild" --undefine=dist rpm/*.spec || rpmbuild -bs --define "%_topdir $(top)/rpmbuild" --undefine=dist "$(spec)"
 	cp "$(top)"/rpmbuild/SRPMS/*.src.rpm "$(outdir)"


### PR DESCRIPTION
- `.copr/Makefile`: Use non-repository path for SPEC