### PR TITLE
add prometheus metrics prefix

### DIFF
--- a/dsc_datatool/__init__.py
+++ b/dsc_datatool/__init__.py
@@ -335,6 +335,8 @@ def main():
         help='"<name>[,<name>,...]" or "<sep><name>[<sep>option=value...]>" Use the specified generators to generate additional datasets.')
     parser.add_argument('--list', action='store_true',
         help='List the available generators, transformers and outputs then exit.')
+    parser.add_argument('--prefix', nargs=1 ,default='dsc',
+        help='Add prefix for prometheus metrics. (default to "dsc")')
     parser.add_argument('--skipped-key', nargs=1, default='-:SKIPPED:-',
         help='Set the special DSC skipped key. (default to "-:SKIPPED:-")')
     parser.add_argument('--skipped-sum-key', nargs=1, default='-:SKIPPED_SUM:-',

--- a/dsc_datatool/output/prometheus.py
+++ b/dsc_datatool/output/prometheus.py
@@ -96,7 +96,7 @@ class Prometheus(Output):
         for dataset in datasets:
             self.type_def = '# TYPE %s gauge' % _key(dataset.name.lower())
             self.type_printed = False
-            tags = '%s{server=%s,node=%s' % (_key(dataset.name.lower()), _val(args.server), _val(args.node))
+            tags = '%s_%s{server=%s,node=%s' % (_key(args.prefix), _key(dataset.name.lower()), _val(args.server), _val(args.node))
             if self.start_timestamp:
                 timestamp = dataset.start_time * 1000
             else:


### PR DESCRIPTION
when I use prometheus's fedration function, I must filter metrics data, so, I think it should add prefix like "dsc_"...

prometheus.yml
```
 49   - job_name: 'federation'
 50     scrape_interval: 10s
 51     honor_labels: true
 52     metrics_path: '/federate'
 53     params:
 54       'match[]':
 61         - '{__name__=~"^redis.*"}'
 62         - '{__name__=~"^ipmi.*"}'
 63         - '{__name__=~"^dsc.*"}'
```

