### PR TITLE
Prometheus metric prefix

### DIFF
--- a/dsc_datatool/output/prometheus.py
+++ b/dsc_datatool/output/prometheus.py
@@ -32,8 +32,9 @@ class Prometheus(Output):
     show_timestamp = True
     start_timestamp = True
     fh = None
-    type_def = ""
+    type_def = ''
     type_printed = False
+    prefix = ''
 
 
     def __init__(self, opts):
@@ -57,6 +58,7 @@ class Prometheus(Output):
             atexit.register(self.close)
         else:
             self.fh = sys.stdout
+        self.prefix = opts.get('prefix', '')
 
 
     def close(self):
@@ -96,7 +98,7 @@ class Prometheus(Output):
         for dataset in datasets:
             self.type_def = '# TYPE %s gauge' % _key(dataset.name.lower())
             self.type_printed = False
-            tags = '%s{server=%s,node=%s' % (_key(dataset.name.lower()), _val(args.server), _val(args.node))
+            tags = '%s%s{server=%s,node=%s' % (self.prefix, _key(dataset.name.lower()), _val(args.server), _val(args.node))
             if self.start_timestamp:
                 timestamp = dataset.start_time * 1000
             else:

--- a/man/man7/dsc-datatool-output-prometheus.7
+++ b/man/man7/dsc-datatool-output-prometheus.7
@@ -44,6 +44,9 @@ Specify a file to output to instead of stdout.
 .BR append
 If given, the output will be appended to the file specified rather then
 overwritten.
+.TP
+.BR prefix =<string>
+Use the given string as prefix on all metric names.
 .LP
 .SH "SEE ALSO"
 .BR dsc-datatool (1)


### PR DESCRIPTION
- `output/prometheus`: Close #93: Add module option to set prefix on all metric names